### PR TITLE
feat: add basic react pwa scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.DS_Store
+.dist
+.vite

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GabOnezio App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "gabonezio",
+  "version": "1.0.0",
+  "description": "Demo React app with styled-components and PWA",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests defined\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "styled-components": "^6.1.11",
+    "framer-motion": "^11.0.0",
+    "gsap": "^3.12.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react-swc": "^3.3.2",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0",
+    "vite-plugin-pwa": "^0.16.5"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react'
+import { createGlobalStyle } from 'styled-components'
+import NavBar from './components/NavBar'
+import LoginModal from './components/LoginModal'
+
+const GlobalStyle = createGlobalStyle`
+  @font-face {
+    font-family: 'Glinke';
+    src: url('/fonts/glinke.otf') format('opentype');
+  }
+  body {
+    margin: 0;
+    font-family: 'Glinke', sans-serif;
+    background: #111;
+    color: #fff;
+  }
+`
+
+export default function App() {
+  const [open, setOpen] = useState(false)
+  const [logged, setLogged] = useState(false)
+
+  return (
+    <>
+      <GlobalStyle />
+      <NavBar onLoginClick={() => setOpen(true)} logged={logged} />
+      {open && (
+        <LoginModal onClose={() => setOpen(false)} onLogged={() => setLogged(true)} />
+      )}
+      {logged && <div style={{ padding: '2rem' }}>Dashboard</div>}
+    </>
+  )
+}

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react'
+import styled from 'styled-components'
+import { motion } from 'framer-motion'
+import PasswordInput from './PasswordInput'
+
+const Overlay = styled(motion.div)`
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+
+const Container = styled(motion.div)`
+  background: #000;
+  padding: 2rem;
+  border-radius: 8px;
+  width: 300px;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`
+
+const Input = styled.input`
+  padding: 0.5rem;
+  border-radius: 4px;
+  border: none;
+`
+
+const Button = styled.button`
+  padding: 0.5rem;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+`
+
+export default function LoginModal({ onClose, onLogged }: { onClose: () => void; onLogged: () => void }) {
+  const [mode, setMode] = useState<'login' | 'register'>('login')
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [pass, setPass] = useState('')
+
+  const handleSubmit = () => {
+    if (mode === 'login') {
+      if (email === 'gabrielonezioferreirapessoal@gmail.com' && pass === '12345') {
+        onLogged()
+        onClose()
+      } else {
+        alert('Credenciais inválidas')
+      }
+    } else {
+      alert('Registrado!')
+      onLogged()
+      onClose()
+    }
+  }
+
+  return (
+    <Overlay initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+      <Container initial={{ scale: 0.8 }} animate={{ scale: 1 }}>
+        <h3>{mode === 'login' ? 'Login' : 'Registro'}</h3>
+        {mode === 'register' && (
+          <Input placeholder="nome" value={name} onChange={e => setName(e.target.value)} />
+        )}
+        <Input placeholder="gmail" value={email} onChange={e => setEmail(e.target.value)} />
+        <PasswordInput placeholder="senha" value={pass} onChange={e => setPass(e.target.value)} />
+        <Button onClick={handleSubmit}>{mode === 'login' ? 'Login' : 'Registrar'}</Button>
+        <Button onClick={() => setMode(mode === 'login' ? 'register' : 'login')}>
+          {mode === 'login' ? 'Criar conta' : 'Já tenho conta'}
+        </Button>
+        <Button onClick={onClose}>Fechar</Button>
+      </Container>
+    </Overlay>
+  )
+}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import styled from 'styled-components'
+import { motion, AnimatePresence } from 'framer-motion'
+
+const Bar = styled.nav`
+  position: fixed;
+  top: 0;
+  width: 100%;
+  height: 60px;
+  backdrop-filter: blur(10px);
+  background: rgba(255, 255, 255, 0.1);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 1rem;
+  color: #fff;
+`
+
+const Profile = styled(motion.div)`
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.3);
+  cursor: pointer;
+  position: relative;
+`
+
+const Tooltip = styled(motion.div)`
+  position: absolute;
+  right: 0;
+  top: 50px;
+  background: #000;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  white-space: nowrap;
+`
+
+export default function NavBar({ onLoginClick, logged }: { onLoginClick: () => void; logged: boolean }) {
+  const [hover, setHover] = React.useState(false)
+  return (
+    <Bar>
+      <div>GabOnezio</div>
+      <Profile
+        onClick={onLoginClick}
+        onMouseEnter={() => setHover(true)}
+        onMouseLeave={() => setHover(false)}
+        whileHover={{ scale: 1.1 }}
+      >
+        <AnimatePresence>
+          {hover && !logged && (
+            <Tooltip initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+              se registre ou faça um login
+            </Tooltip>
+          )}
+        </AnimatePresence>
+      </Profile>
+    </Bar>
+  )
+}

--- a/src/components/PasswordInput.tsx
+++ b/src/components/PasswordInput.tsx
@@ -1,0 +1,70 @@
+import React, { useState, useRef, useEffect } from 'react'
+import styled from 'styled-components'
+import { gsap } from 'gsap'
+
+const Wrapper = styled.div`
+  position: relative;
+  display: flex;
+`
+
+const Input = styled.input`
+  padding-right: 40px;
+`
+
+const EyeContainer = styled.div`
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #fff;
+  overflow: hidden;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+
+const Pupil = styled.div`
+  width: 8px;
+  height: 8px;
+  background: #000;
+  border-radius: 50%;
+`
+
+const Closed = styled.div`
+  width: 16px;
+  height: 2px;
+  background: #000;
+`
+
+export default function PasswordInput(props: React.InputHTMLAttributes<HTMLInputElement>) {
+  const [show, setShow] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const pupilRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const input = inputRef.current
+    if (!input) return
+    const move = (e: MouseEvent) => {
+      const rect = input.getBoundingClientRect()
+      const x = (e.clientX - rect.left) / rect.width - 0.5
+      const y = (e.clientY - rect.top) / rect.height - 0.5
+      const max = 6
+      gsap.to(pupilRef.current, { x: x * max, y: y * max, duration: 0.2 })
+    }
+    input.addEventListener('mousemove', move)
+    return () => input.removeEventListener('mousemove', move)
+  }, [])
+
+  return (
+    <Wrapper>
+      <Input ref={inputRef} type={show ? 'text' : 'password'} {...props} />
+      <EyeContainer onClick={() => setShow(!show)}>
+        {show ? <Pupil ref={pupilRef} /> : <Closed />}
+      </EyeContainer>
+    </Wrapper>
+  )
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node"
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react-swc'
+import { VitePWA } from 'vite-plugin-pwa'
+
+export default defineConfig({
+  plugins: [
+    react(),
+    VitePWA({
+      registerType: 'autoUpdate'
+    })
+  ]
+})


### PR DESCRIPTION
## Summary
- scaffold React + Vite project with SWC and PWA plugin
- add translucent navbar and login modal with animated password eye

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0f79f70088332b2f3628774c7d789